### PR TITLE
Don't explicitly inherit from `object`

### DIFF
--- a/tynt/core.py
+++ b/tynt/core.py
@@ -13,7 +13,7 @@ __all__ = ['FilterGenerator', 'Filter']
 data_path = os.path.join(os.path.dirname(__file__), 'data', 'fft.fits.zip')
 
 
-class FilterGenerator(object):
+class FilterGenerator:
     """
     Astronomical filter object generator.
     """
@@ -180,7 +180,7 @@ class FilterGenerator(object):
         )
 
 
-class Filter(object):
+class Filter:
     """
     Astronomical filter.
     """

--- a/tynt/download.py
+++ b/tynt/download.py
@@ -9,7 +9,7 @@ __all__ = ['DownloadManager']
 n_terms = 10
 
 
-class DownloadManager(object):
+class DownloadManager:
     """
     Manager for downloads from the SVO filter service.
     """


### PR DESCRIPTION
In Python 3, all classes implicitly derive from `object`.